### PR TITLE
fix: exclude test files from code coverage analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,9 @@ jobs:
         lcov --capture --directory . --output-file coverage.info
         lcov --remove coverage.info '/usr/*' --output-file coverage.info
         lcov --remove coverage.info '*/thirdparty/*' --output-file coverage.info
+        lcov --remove coverage.info '*/test/*' --output-file coverage.info
+        lcov --remove coverage.info '*_tests.cpp' --output-file coverage.info
+        lcov --remove coverage.info '*/doctest/*' --output-file coverage.info
         lcov --list coverage.info
         
     - name: Coverage report comment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,14 @@ jobs:
       run: |
         cd test/build
         lcov --capture --directory . --output-file coverage.info
-        lcov --remove coverage.info '/usr/*' --output-file coverage.info
-        lcov --remove coverage.info '*/thirdparty/*' --output-file coverage.info
-        lcov --remove coverage.info '*/test/*' --output-file coverage.info
-        lcov --remove coverage.info '*_tests.cpp' --output-file coverage.info
-        lcov --remove coverage.info '*/doctest/*' --output-file coverage.info
+        lcov --remove coverage.info \
+          '/usr/*' \
+          '*/thirdparty/*' \
+          '*/test/*' \
+          '*_tests.cpp' \
+          '*/doctest/*' \
+          --output-file coverage.info \
+          --ignore-errors unused
         lcov --list coverage.info
         
     - name: Coverage report comment


### PR DESCRIPTION
- Add lcov --remove patterns to exclude test directory from coverage
- Remove test/*.cpp files and doctest framework files from coverage reports
- Ensure coverage only measures production code in src/ directory
- Coverage reports will now correctly show only source code coverage, not test code